### PR TITLE
docs: improve release workflows and auto-release safety

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -1,4 +1,4 @@
-name: Auto Release
+name: Auto Release on PR Merge
 
 on:
   pull_request:
@@ -8,13 +8,11 @@ on:
 
 jobs:
   check-release:
-    # Only run for merged PRs from maintainers or with proper labels
+    # Only run for merged PRs with explicit release labels
+    # This prevents accidental releases - you must intentionally add a release label
     if: |
       github.event.pull_request.merged == true && 
-      (github.event.pull_request.author_association == 'OWNER' || 
-       github.event.pull_request.author_association == 'MEMBER' || 
-       github.event.pull_request.author_association == 'COLLABORATOR' ||
-       contains(github.event.pull_request.labels.*.name, 'release:patch') ||
+      (contains(github.event.pull_request.labels.*.name, 'release:patch') ||
        contains(github.event.pull_request.labels.*.name, 'release:minor') ||
        contains(github.event.pull_request.labels.*.name, 'release:major'))
     runs-on: ubuntu-latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -126,7 +126,7 @@ pnpm audit           # Check for vulnerabilities
 
 We use GitHub Actions for all production releases to ensure consistency and security.
 
-#### For Maintainers: Production Releases
+#### For Maintainers: Manual Releases
 
 ```bash
 # Recommended: Use the production release script
@@ -139,6 +139,15 @@ We use GitHub Actions for all production releases to ensure consistency and secu
 # 2. Trigger GitHub Actions release workflow
 # 3. Show you how to monitor progress
 ```
+
+#### For Maintainers: Automated PR Releases
+
+Add one of these labels to a PR to trigger an automatic release when merged:
+- `release:patch` - For bug fixes
+- `release:minor` - For new features
+- `release:major` - For breaking changes
+
+**Note**: Only PRs with explicit release labels will trigger releases. This prevents accidental releases.
 
 #### For Contributors: Testing Releases
 

--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ These require server configuration access, which you don't have with GitHub Page
 
 We use GitHub Actions for all production releases to ensure consistency and security.
 
-#### Production Releases (Recommended)
+#### Option 1: Manual Release (Recommended)
 
 ```bash
 # Using our convenience script
@@ -195,6 +195,15 @@ We use GitHub Actions for all production releases to ensure consistency and secu
 # Or directly with GitHub CLI
 gh workflow run release.yml --field version_type=patch --field create_github_release=true
 ```
+
+#### Option 2: Automated PR Release
+
+Add a release label to your PR before merging:
+- `release:patch` - Bug fixes
+- `release:minor` - New features
+- `release:major` - Breaking changes
+
+The release will trigger automatically when the PR is merged.
 
 #### Local Development
 


### PR DESCRIPTION
## Summary

This PR improves our release workflows by:

- Making auto-release safer - now requires explicit release labels
- Documenting both manual and automated release options  
- Clarifying that release labels are intentional triggers
- Preventing accidental releases by removing automatic triggers for maintainer PRs

## Changes

- Updated auto-release workflow to only trigger with explicit `release:*` labels
- Updated README and CONTRIBUTING docs to explain both release options
- Made it clear when to use each workflow

## Testing

This PR itself will test the auto-release workflow. I'll add the `release:patch` label to trigger v1.4.1 when merged.

## Type of Change

- 📚 Documentation update
- 🔧 Development tooling improvement