### PR TITLE
Test auto-release workflow with v1.4.1

### DIFF
--- a/.github/SETUP.md
+++ b/.github/SETUP.md
@@ -34,13 +34,15 @@ The npm automation token is required for publishing packages to npm.
 - **Required**: NPM_TOKEN secret
 
 ### Auto Release (auto-release.yml)
-- **Triggers**: When PR is merged to main
+- **Triggers**: When PR is merged to main with a release label
 - **Purpose**: Automatically release based on PR labels
 - **Labels**:
   - `release:patch` - Triggers patch release (1.0.0 → 1.0.1)
   - `release:minor` - Triggers minor release (1.0.0 → 1.1.0)
   - `release:major` - Triggers major release (1.0.0 → 2.0.0)
-- **Required**: NPM_TOKEN secret
+- **Required**: 
+  - NPM_TOKEN secret
+  - The release.yml workflow must include `workflow_call` trigger
 
 ### Label Sync (sync-labels.yml)
 - **Triggers**: Changes to .github/labels.yml or manual


### PR DESCRIPTION
## Summary

This PR tests the fixed auto-release workflow by:
- Adding documentation about workflow_call requirement
- Will trigger v1.4.1 when merged with the `release:patch` label

## Previous Issue

The first attempt failed because release.yml wasn't reusable. This has been fixed in the main branch.

## Testing

When this PR is merged with the `release:patch` label, it should automatically trigger v1.4.1 release.

## Type of Change

- 📚 Documentation update
- 🧪 Testing auto-release workflow