### PR TITLE
Test fixed auto-release workflow - v1.4.1

### DIFF
--- a/.github/SETUP.md
+++ b/.github/SETUP.md
@@ -61,6 +61,7 @@ The workflows use the built-in `GITHUB_TOKEN` with these permissions:
 1. **Test CI**: Open a PR to see all checks run
 2. **Test Labels**: Run the "Sync Labels" workflow manually
 3. **Test Release**: Use workflow dispatch to create a test release
+4. **Test Auto-Release**: Add a `release:*` label to a PR before merging
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Summary

This PR tests the now-fixed auto-release workflow. Previous attempts failed due to:
1. Missing `workflow_call` trigger in release.yml ✅ Fixed
2. Input handling for both workflow_dispatch and workflow_call ✅ Fixed

## Changes

- Minor documentation update to trigger the release

## Expected Result

When merged with the `release:patch` label, this should successfully trigger v1.4.1 release.

---

🤞 Third time's the charm\!